### PR TITLE
Add extra check for rollback button

### DIFF
--- a/app/views/deployments/list.html.haml
+++ b/app/views/deployments/list.html.haml
@@ -26,6 +26,6 @@
       = link_to pull.title, deployments_details_path(pull_id: pull.pull_number)
     .small-12.large-3.columns.deployment-time
       = pull.merged_at
-      -if index == 0
+      -if index == 0 && pull.rollback_commit.present?
         %br
         %a.button.alert.rollback.tiny{ href: rollback_path(commit: pull.rollback_commit), target: '_blank' } ⚠️ Revert PR ##{ pull.pull_number }


### PR DESCRIPTION
If there's only a single PR to production, the deployments dashboard 500s. Since you can't revert, don't show the button